### PR TITLE
32 update 몬스터 사망 요청 및 적 몬스터 사망 통지 패킷

### DIFF
--- a/public/src/game.js
+++ b/public/src/game.js
@@ -319,17 +319,18 @@ class Game {
       if (monster.hp > 0) {
         const Attacked = monster.move();
         monster.draw(this.ctx);
+
         if (!Attacked) {
           continue;
         }
-        const attackedSound = new Audio('sounds/attacked.wav');
-        attackedSound.volume = 0.3;
-        attackedSound.play();
-        // TODO. 몬스터가 기지를 공격했을 때 서버로 이벤트 전송
+        // const attackedSound = new Audio('sounds/attacked.wav');
+        // attackedSound.volume = 0.3;
+        // attackedSound.play();
         const payload = {
           monsterDamage: monster.attackPower,
         };
         Socket.sendEventProto(packetTypes.BASE_ATTACKED_REQUEST, payload);
+        this.monsters.splice(i, 1);
       } else {
         const payload = {
           monsterIndex: monster.index,

--- a/public/src/game.js
+++ b/public/src/game.js
@@ -301,7 +301,10 @@ class Game {
           this.monsters.splice(i, 1);
         }
       } else {
-        // TODO. 몬스터 사망 이벤트 전송
+        const payload = {
+          monsterIndex: monster.index,
+        };
+        Socket.sendEventProto(packetTypes.MONSTER_KILL_REQUEST, payload);
         this.monsters.splice(i, 1);
       }
     }

--- a/public/src/handlers/index.handler.js
+++ b/public/src/handlers/index.handler.js
@@ -1,6 +1,7 @@
 import signUpHandler from '../../../src/handlers/sign-up.handler.js';
 import packetTypes from '../constants/packet-types.constants.js';
 import matchFoundNotificationHandler from './match-found.handler.js';
+import monsterKillNotificationHandler from './monster-kill.handler.js';
 import monsterSpawnNotificationHandler from './monster-spawn.handler.js';
 import signInHandler from './sign-in.handler.js';
 import towerAttackNotificationHandler from './tower-attack.handler.js';
@@ -16,7 +17,7 @@ const handlerMappings = {
   [packetTypes.TOWER_PURCHASE_RESPONSE]: towerResponseHandler,
   [packetTypes.TOWER_PURCHASE_NOTIFICATION]: towerNotificationHandler,
   [packetTypes.MONSTER_SPAWN_NOTIFICATION]: monsterSpawnNotificationHandler,
-  // ...
+  [packetTypes.MONSTER_KILL_NOTIFICATION]: monsterKillNotificationHandler,
 };
 
 export const getHandlerByPacketType = (packetType) => {

--- a/public/src/handlers/monster-kill.handler.js
+++ b/public/src/handlers/monster-kill.handler.js
@@ -4,7 +4,10 @@ const monsterKillNotificationHandler = ({ socket, packetType, payload }) => {
   const { monsterIndex } = payload;
 
   const game = Game.getInstance();
-  game.opponentMonsters.splice(monsterIndex, 1);
+  const targetIndex = game.opponentMonsters.findIndex((monster) => {
+    return monsterIndex === monster.index;
+  });
+  game.opponentMonsters.splice(targetIndex, 1);
 };
 
 export default monsterKillNotificationHandler;

--- a/public/src/handlers/monster-kill.handler.js
+++ b/public/src/handlers/monster-kill.handler.js
@@ -1,0 +1,10 @@
+import Game from '../game.js';
+
+const monsterKillNotificationHandler = ({ socket, packetType, payload }) => {
+  const { monsterIndex } = payload;
+
+  const game = Game.getInstance();
+  game.opponentMonsters.splice(monsterIndex, 1);
+};
+
+export default monsterKillNotificationHandler;

--- a/public/src/protobuf/notifications.proto
+++ b/public/src/protobuf/notifications.proto
@@ -32,7 +32,7 @@ message S2C_MonsterSpawnNotification {
 }
 
 message S2C_MonsterKillNotification {
-
+    uint32 monsterIndex = 1;
 }
 
 message S2C_GameOverNotification {

--- a/public/src/protobuf/requests.proto
+++ b/public/src/protobuf/requests.proto
@@ -36,7 +36,7 @@ message C2S_MonsterSpawnRequest {
 }
 
 message C2S_MonsterKillRequest {
-
+    uint32 monsterIndex = 1;
 }
 
 message C2S_BaseAttackedRequest {

--- a/src/constants/handler.constants.js
+++ b/src/constants/handler.constants.js
@@ -1,5 +1,5 @@
 import { matchRequestHandler } from '../handlers/game.handler.js';
-import { monsterSpawnHandler } from '../handlers/monster.handler.js';
+import { monsterKillRequestHandler, monsterSpawnHandler } from '../handlers/monster.handler.js';
 import signInHandler from '../handlers/sign-in.handler.js';
 import { towerAttackRequestHandler } from '../handlers/tower.handler.js';
 import packetTypes from './packet-types.constants.js';
@@ -31,6 +31,9 @@ const handlerMappings = {
   },
   [packetTypes.MONSTER_SPAWN_REQUEST]: {
     handler: monsterSpawnHandler,
+  },
+  [packetTypes.MONSTER_KILL_REQUEST]: {
+    handler: monsterKillRequestHandler,
   },
 };
 

--- a/src/handlers/base.handler.js
+++ b/src/handlers/base.handler.js
@@ -10,9 +10,10 @@ const baseHandler = async (socket, userId, packetType, payload, io) => {
   const game = gsm.getGame(socket.gameId);
 
   // 게임이 진행 중이 아닐 때 정보 갱신 방지
-  if (!game.isPlaying()) {
-    return;
-  }
+  // if (!game.isPlaying()) {
+  //   return;
+  // }
+
   // await userRedis.setUserData(userDB.userId, { test: 'temp' });
   const { monsterDamage } = payload;
   // console.log(`monsterDamage: ${monsterDamage}`);

--- a/src/handlers/monster.handler.js
+++ b/src/handlers/monster.handler.js
@@ -16,3 +16,16 @@ export const monsterSpawnHandler = async (socket, userId, packetType, payload, i
 
   socket.broadcast.emit('event', packet);
 };
+
+export const monsterKillRequestHandler = async (socket, userId, packetType, payload, io) => {
+  const { monsterIndex } = payload;
+
+  const notPacketType = packetTypes.MONSTER_KILL_NOTIFICATION;
+  const notificationPacket = new NotificationPacket('적 몬스터 사망', { monsterIndex });
+
+  const packet = serialize(notPacketType, notificationPacket);
+  // const test = deserialize(packet, true);
+  // console.log(test);
+
+  socket.broadcast.emit('event', packet);
+};

--- a/src/protobuf/notifications.proto
+++ b/src/protobuf/notifications.proto
@@ -32,7 +32,7 @@ message S2C_MonsterSpawnNotification {
 }
 
 message S2C_MonsterKillNotification {
-
+    uint32 monsterIndex = 1;
 }
 
 message S2C_GameOverNotification {

--- a/src/protobuf/requests.proto
+++ b/src/protobuf/requests.proto
@@ -36,7 +36,7 @@ message C2S_MonsterSpawnRequest {
 }
 
 message C2S_MonsterKillRequest {
-
+    uint32 monsterIndex = 1;
 }
 
 message C2S_BaseAttackedRequest {


### PR DESCRIPTION
### 해결 완료 이슈

- #32 

### 주요 내용

- 몬스터 사망 시 요청 패킷 전송
- 적 몬스터 사망 시 서버에서 상대 클라이언트 통지 패킷 전송
- 몬스터 배열에서 해당 몬스터 삭제